### PR TITLE
docs: fix npm Repository link and rewrite README [DVR-165]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,90 +1,131 @@
 # @aptos-labs/script-composer-pack
 
-Generate Move script payload helpers from `@aptos-labs/aptos-dynamic-transaction-composer`.
+Build batched Aptos Move script payloads using the
+[dynamic transaction composer](https://github.com/aptos-labs/aptos-dynamic-transaction-composer)
+— with the WASM **pre-bundled and base64-inlined**, so no network fetch or manual asset loading
+is required at runtime.
 
-## Requirements
+## Compatibility
 
-- Node.js 18+
-- pnpm
+| Peer dependency | Supported range |
+|---|---|
+| `@aptos-labs/ts-sdk` | `^3.0.0 \|\| ^4.0.0 \|\| ^5.0.0 \|\| ^6.0.0 \|\| ^7.0.0` |
+| `@aptos-labs/aptos-dynamic-transaction-composer` | `^0.1.7` |
+
+Node.js 18+ required.
 
 ## Install
 
 ```bash
+# pnpm
+pnpm add @aptos-labs/script-composer-pack \
+     @aptos-labs/aptos-dynamic-transaction-composer \
+     @aptos-labs/ts-sdk
+
+# npm
+npm install @aptos-labs/script-composer-pack \
+            @aptos-labs/aptos-dynamic-transaction-composer \
+            @aptos-labs/ts-sdk
+
+# yarn
+yarn add @aptos-labs/script-composer-pack \
+         @aptos-labs/aptos-dynamic-transaction-composer \
+         @aptos-labs/ts-sdk
+```
+
+Both peer dependencies must be installed by the consumer.
+
+## Usage
+
+```ts
+import {
+  initSync,
+  wasmModule,
+  TransactionComposer,
+  CallArgument,
+} from "@aptos-labs/script-composer-pack";
+import { Aptos, AptosConfig, Network } from "@aptos-labs/ts-sdk";
+import { BCS } from "@aptos-labs/ts-sdk";
+
+// Initialize the bundled WASM once at startup — no network fetch needed.
+initSync({ module: wasmModule });
+
+// Build a batched script that calls two Move functions in sequence.
+const composer = TransactionComposer.single_signer();
+
+// First call: withdraw coins from the signer's account.
+const amountBcs = BCS.bcsSerializeUint64(100_000_000n);
+const [withdrawnCoin] = composer.add_batched_call(
+  "0x1::coin",
+  "withdraw",
+  ["0x1::aptos_coin::AptosCoin"],
+  [CallArgument.newSigner(0), CallArgument.newBytes(amountBcs)],
+);
+
+// Second call: deposit the returned value from the first call.
+const recipientBcs = /* BCS-encoded AccountAddress */ new Uint8Array(32);
+composer.add_batched_call(
+  "0x1::coin",
+  "deposit",
+  ["0x1::aptos_coin::AptosCoin"],
+  [CallArgument.newBytes(recipientBcs), withdrawnCoin],
+);
+
+// Serialize into a Move script payload (Uint8Array).
+const scriptPayload = composer.generate_batched_calls(/* with_metadata */ true);
+
+// Hand scriptPayload to @aptos-labs/ts-sdk to build and submit a script transaction.
+```
+
+To decompile a serialized script back into its function calls (useful for display or auditing):
+
+```ts
+import { generate_batched_call_payload_wasm } from "@aptos-labs/script-composer-pack";
+
+const calls = generate_batched_call_payload_wasm(scriptPayload); // MoveFunctionCall[]
+```
+
+## API
+
+| Export | Description |
+|---|---|
+| `initSync({ module })` | Initialize the bundled WASM module synchronously. Call once before any other API. |
+| `wasmModule` | Pre-compiled `WebAssembly.Module` — pass directly to `initSync`. |
+| `TransactionComposer` | Core builder. Use `single_signer()` or `multi_signer(n)` to construct, then chain `add_batched_call(...)` calls, and finally `generate_batched_calls(withMetadata)` to serialize. |
+| `CallArgument` | Represents a call argument: `newSigner(idx)` for a signer, `newBytes(bytes)` for a BCS-encoded value, or the return value of a previous `add_batched_call`. |
+| `MoveFunctionCall` | Represents a single Move function call inside a deserialized script. |
+| `PreviousResult` | Internal: a return value from a prior `add_batched_call` that can be forwarded as an argument. |
+| `generate_batched_call_payload_wasm(script)` | Decompiles a serialized `Uint8Array` script into `MoveFunctionCall[]`. |
+
+## Development
+
+```bash
 pnpm install
-```
+pnpm build        # outputs CJS + ESM bundles to dist/
 
-## Build
-
-```bash
-pnpm build
-```
-
-## Version Bump CLI
-
-This repo includes a generic version bump CLI at `scripts/bump-version.mjs`.
-
-### Command
-
-```bash
-pnpm run version:bump -- <major|minor|patch|prerelease|X.Y.Z> [options]
-```
-
-`X.Y.Z` uses strict SemVer parsing and supports prerelease/build metadata,
-for example `1.4.0-rc.1` and `1.4.0+build.7`.
-
-### Options
-
-- `--file <path>`: target `package.json` (default: `./package.json`)
-- `--pre <id>`: prerelease id for `prerelease` action (default: `rc`)
-- `--dry-run`: preview only, no file changes
-
-### Examples
-
-```bash
-# bump patch version
-pnpm run version:bump -- patch
-
-# preview minor bump
-pnpm run version:bump -- minor --dry-run
-
-# set exact version
-pnpm run version:bump -- 1.4.0
-
-# create/increment prerelease
-pnpm run version:bump -- prerelease --pre beta
-
-# bump another package.json
-pnpm run version:bump -- patch --file ./packages/foo/package.json
-```
-
-## Recommended Upgrade Flow
-
-1. Pull latest `main`.
-2. Create a new branch for the release.
-3. Preview target version:
-
-```bash
+# Preview a version bump without writing
 pnpm run version:bump -- patch --dry-run
+
+# Apply a version bump
+pnpm run version:bump -- patch   # or minor / major / 1.2.3
 ```
 
-4. Apply version bump:
+## Release
+
+Releases are automated via GitHub Actions. After merging a version-bump PR:
 
 ```bash
-pnpm run version:bump -- patch
+git tag v<version>      # e.g. git tag v0.2.4
+git push origin v<version>
 ```
 
-5. Verify build:
+The [release workflow](.github/workflows/release.yml) verifies the tag matches
+`package.json`, checks the version hasn't been published yet, builds, publishes to npm via
+OIDC Trusted Publishing, and creates a GitHub Release.
 
-```bash
-pnpm build
-```
+**Prerequisite:** an npm Trusted Publisher must be configured on npmjs.com for this repository
+before pushing the first tag.
 
-6. Commit and push:
+## License
 
-```bash
-git add package.json
-git commit -m "chore: bump version to <new-version>"
-git push -u origin <your-branch>
-```
-
-7. Open PR.
+Apache-2.0 © [Aptos Labs](https://aptoslabs.com)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,17 @@ Build batched Aptos Move script payloads using the
 — with the WASM **pre-bundled and base64-inlined**, so no network fetch or manual asset loading
 is required at runtime.
 
+## What this package does
+
+This package bundles the `@aptos-labs/aptos-dynamic-transaction-composer` WebAssembly module
+directly into JavaScript, eliminating the need for runtime WASM file loading or manual
+initialization. Call `initSync()` once, then use `TransactionComposer` to compose and serialize
+batched Move function calls into a script payload.
+
+**This is a low-level, zero-dependency binding.** For a higher-level SDK with transaction
+building, signing, and submission, see
+[`@aptos-labs/script-composer-sdk`](https://github.com/aptos-labs/script-composer-sdk).
+
 ## Compatibility
 
 | Peer dependency | Supported range |

--- a/package.json
+++ b/package.json
@@ -3,12 +3,15 @@
   "collaborators": [
     "Aptos Labs <opensource@aptoslabs.com>"
   ],
-  "description": "Generating Move Script from composer",
+  "description": "Self-contained WASM bundle for building batched Aptos Move script payloads via the dynamic transaction composer.",
   "version": "0.2.4",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/aptos-labs/aptos-core"
+    "url": "git+https://github.com/aptos-labs/script-composer-pack.git"
+  },
+  "bugs": {
+    "url": "https://github.com/aptos-labs/script-composer-pack/issues"
   },
   "files": [
     "dist",
@@ -19,7 +22,7 @@
   "main": "dist/cjs/main.js",
   "module": "dist/esm/main.mjs",
   "types": "dist/main.d.ts",
-  "homepage": "https://aptoslabs.com",
+  "homepage": "https://github.com/aptos-labs/script-composer-pack#readme",
   "sideEffects": [
     "./snippets/*"
   ],


### PR DESCRIPTION
## Summary

Fixes the two issues visible on the [npm package page](https://www.npmjs.com/package/@aptos-labs/script-composer-pack):

**1. Broken Repository link** — \`repository.url\` pointed to \`aptos-core\` (the old monorepo). Updated to the correct standalone repo URL so the npm sidebar links here.

**2. README rewrite** — the old README was entirely dev/build/version-bump notes. The new version covers:
- What the package does and its key value proposition (WASM pre-bundled, no network fetch)
- Compatibility table (ts-sdk ^3–7, composer ^0.1.7)
- Install snippets (pnpm / npm / yarn)
- Realistic usage example with \`initSync\`, \`TransactionComposer\`, \`CallArgument\`, and chained calls
- \`generate_batched_call_payload_wasm\` decompilation example
- API reference table for all exports
- Condensed dev notes and release flow (cross-references DVR-164 release workflow)

**\`package.json\` fields changed:**
- \`description\` — more informative one-liner
- \`repository.url\` — corrected to this repo
- \`homepage\` — points to repo README anchor instead of \`aptoslabs.com\`
- \`bugs.url\` — added (was missing)

## Linear

DVR-165

## Test plan

- [x] \`node -p "require('./package.json').repository.url"\` → \`git+https://github.com/aptos-labs/script-composer-pack.git\`
- [x] \`node -p "require('./package.json').homepage"\` → \`https://github.com/aptos-labs/script-composer-pack#readme\`
- [x] \`node -p "require('./package.json').bugs.url"\` → \`https://github.com/aptos-labs/script-composer-pack/issues\`
- [x] All symbols used in README code blocks (\`initSync\`, \`wasmModule\`, \`TransactionComposer\`, \`CallArgument\`, \`generate_batched_call_payload_wasm\`) appear in \`dist/main.d.ts\` exports
- [x] \`pnpm build\` succeeds — CJS + ESM + types output clean ⚡️

🤖 Generated with [Claude Code](https://claude.com/claude-code)