### PR TITLE
fix: allow esbuild postinstall in pnpm [DVR-166]

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,9 @@
       }
     }
   },
+  "pnpm": {
+    "onlyBuiltDependencies": ["esbuild"]
+  },
   "scripts": {
     "build": "npx tsup",
     "version:bump": "node ./scripts/bump-version.mjs",


### PR DESCRIPTION
## Summary

Fixes the CI failure in the release workflow where `pnpm install --frozen-lockfile` exits with:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: esbuild@0.25.4
```

pnpm v10 blocks all postinstall scripts by default. `esbuild` needs its postinstall to download its platform binary — without it the binary is missing and `pnpm build` fails.

**Fix:** add `onlyBuiltDependencies: [esbuild]` to both `package.json` (under the `pnpm` key) and `pnpm-lock.yaml` (top-level field), which explicitly authorises `esbuild`'s build script.

## Linear

Closes DVR-166

## Test plan

- [x] `pnpm install --frozen-lockfile` passes locally with no warnings
- [ ] Merge and re-run the `v0.2.4` release workflow — Install dependencies step should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)